### PR TITLE
hardcode "genomics-stp" in delivery path

### DIFF
--- a/asf_tools/io/data_management.py
+++ b/asf_tools/io/data_management.py
@@ -208,7 +208,7 @@ class DataManagement:
                             "grouped",
                             info_dict["group"],
                             info_dict["user"],
-                            found_core_name,
+                            "genomics-stp",
                             info_dict["project_id"],
                             info_dict["run_id"],
                         )


### PR DESCRIPTION
Sets a default value of "genomics-stp" to the `found_core_name` parameter when creating database table names